### PR TITLE
Better errors and memory management

### DIFF
--- a/src/entities.rs
+++ b/src/entities.rs
@@ -77,12 +77,12 @@ impl Entities {
 
     pub fn is_alive(&self, entity: EcsId) -> bool {
         let stored_generation = self
-        .generations
-        .get(entity.uindex())
-        .expect(format!("could not get generation for {}", entity).as_ref());
-        
+            .generations
+            .get(entity.uindex())
+            .expect(format!("could not get generation for {}", entity).as_ref());
+
         let generation = entity.generation();
-        
+
         use std::cmp::Ordering;
         match generation.cmp(stored_generation) {
             Ordering::Less => false,

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -97,6 +97,8 @@ impl Entities {
 
 #[cfg(test)]
 mod tests {
+    use crate::{World, spawn};
+
     use super::*;
 
     #[test]
@@ -146,7 +148,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "(gen 4294967295, index 4294967295) is not a valid EcsId")]
+    #[should_panic(expected = "could not get generation for (gen 4294967295, index 4294967295)")]
     pub fn despawn_invalid() {
         let entities = Entities::new();
         let invalid_id = EcsId(u64::MAX);
@@ -249,5 +251,14 @@ mod tests {
         assert!(entities.generations.len() == 1);
         assert!(*entities.generations.get(0).unwrap() == 0);
         assert!(entities.despawned.len() == 0);
+    }
+
+    #[test]
+    pub fn build_with_zst() -> () {
+        struct Zero;
+
+        let mut world = World::new();
+        let entity = spawn!(&mut world, Zero);
+        assert!(world.is_alive(entity));
     }
 }

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -76,11 +76,22 @@ impl Entities {
     }
 
     pub fn is_alive(&self, entity: EcsId) -> bool {
-        *self
+        let generation = entity.generation();
+        let stored_generation = self
             .generations
             .get(entity.uindex())
-            .expect(format!("{} is not a valid EcsId", entity).as_ref())
-            == entity.generation()
+            .expect(format!("could not get generation for {}", entity).as_ref());
+        match generation.cmp(stored_generation) {
+            std::cmp::Ordering::Less => {
+                false
+            }
+            std::cmp::Ordering::Equal => {
+                true
+            }
+            std::cmp::Ordering::Greater => {
+                panic!("Stored generation {} greater than entity generation {} for entity {}", stored_generation, generation, entity);
+            }
+        }
     }
 }
 

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -76,12 +76,13 @@ impl Entities {
     }
 
     pub fn is_alive(&self, entity: EcsId) -> bool {
-        let generation = entity.generation();
         let stored_generation = self
-            .generations
-            .get(entity.uindex())
-            .expect(format!("could not get generation for {}", entity).as_ref());
-            
+        .generations
+        .get(entity.uindex())
+        .expect(format!("could not get generation for {}", entity).as_ref());
+        
+        let generation = entity.generation();
+        
         use std::cmp::Ordering;
         match generation.cmp(stored_generation) {
             Ordering::Less => false,

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -55,10 +55,10 @@ impl Entities {
             }
         };
 
-        assert!(
-            idx <= u32::MAX as usize,
-            format!("Out of generation indexes, tried to use index {}", idx)
-        );
+        if idx > u32::MAX as usize {
+            todo!("Handle out of generations");
+        }
+
         let generation = self.generations[idx];
         EcsId::new(idx as u32, generation)
     }
@@ -81,23 +81,22 @@ impl Entities {
             .generations
             .get(entity.uindex())
             .expect(format!("could not get generation for {}", entity).as_ref());
+            
+        use std::cmp::Ordering;
         match generation.cmp(stored_generation) {
-            std::cmp::Ordering::Less => {
-                false
-            }
-            std::cmp::Ordering::Equal => {
-                true
-            }
-            std::cmp::Ordering::Greater => {
-                panic!("Stored generation {} greater than entity generation {} for entity {}", stored_generation, generation, entity);
-            }
+            Ordering::Less => false,
+            Ordering::Equal => true,
+            Ordering::Greater => panic!(
+                "Stored generation {} greater than entity generation {} for entity {}",
+                stored_generation, generation, entity
+            ),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{World, spawn};
+    use crate::{spawn, World};
 
     use super::*;
 

--- a/src/entity_builder.rs
+++ b/src/entity_builder.rs
@@ -1,4 +1,4 @@
-use std::{alloc::Layout, mem, ptr::NonNull};
+use std::{alloc::Layout, ptr::NonNull};
 use std::{
     alloc::{alloc, dealloc, handle_alloc_error, realloc},
     collections::HashMap,
@@ -101,7 +101,7 @@ impl<'a> EntityBuilder<'a> {
         if self.cap == 0 {
             let layout = std::alloc::Layout::from_size_align(new_size, 1).unwrap();
             let new_ptr = unsafe { alloc(layout) };
-            
+
             self.data = NonNull::new(new_ptr).unwrap_or_else(|| handle_alloc_error(layout));
             self.cap = new_size;
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(unsafe_block_in_unsafe_fn)]
 #![feature(unsafe_cell_get_mut)]
 #![feature(option_unwrap_none)]
+#![feature(option_expect_none)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 pub mod entities;

--- a/src/untyped_vec.rs
+++ b/src/untyped_vec.rs
@@ -79,9 +79,8 @@ impl UntypedVec {
         if self.cap == 0 {
             let new_cap = self.type_info.layout.size() * 4;
 
-            // Safe because we assert new cap is not 0
             let layout = Layout::from_size_align(new_cap, self.type_info.layout.align()).unwrap();
-
+            // Safe because type info size is always non-zero and thus new_cap is always non-zero
             let ptr = unsafe { alloc(layout) };
             self.data = NonNull::new(ptr).unwrap_or_else(|| handle_alloc_error(layout));
 
@@ -89,12 +88,12 @@ impl UntypedVec {
         } else {
             let new_cap = self.cap * 2;
             assert!(new_cap < isize::MAX as usize);
-            // Safe because we assert cap is not 0
             let old_layout =
                 Layout::from_size_align(self.cap, self.type_info.layout.align()).unwrap();
 
             // Safe because the pointer we pass in is always made from this allocator because
             // the only way to get a cap > 0 is if the other branch has run and allocated memory
+            // the layout is also safe because cap is always greater than zero here
             // Safe because new_cap is < isize::MAX
             let ptr = unsafe { realloc(self.data.as_ptr(), old_layout, new_cap) };
             self.data = NonNull::new(ptr).unwrap_or_else(|| handle_alloc_error(old_layout));

--- a/src/untyped_vec.rs
+++ b/src/untyped_vec.rs
@@ -81,8 +81,10 @@ impl UntypedVec {
             let layout = Layout::from_size_align(new_cap, self.type_info.layout.align()).unwrap();
 
             // Safe because we assert size is not 0
-            let ptr: *mut u8 = unsafe { alloc(layout) };
-            let ptr = NonNull::new(ptr).unwrap();
+            let ptr = unsafe {
+                let ptr = alloc(layout);
+                NonNull::new_unchecked(ptr)
+            };
 
             self.cap = new_cap;
             self.data = ptr;
@@ -96,9 +98,10 @@ impl UntypedVec {
             // Safe because the pointer we pass in is always made from this allocator because
             // the only way to get a cap > 0 is if the other branch has run and allocated memory
             // Safe because new_cap is < isize::MAX
-            let ptr = self.data.as_ptr();
-            let ptr: *mut u8 = unsafe { realloc(ptr, old_layout, new_cap) };
-            let ptr = NonNull::new(ptr).unwrap();
+            let ptr = unsafe {
+                let ptr = realloc(self.data.as_ptr(), old_layout, new_cap);
+                NonNull::new_unchecked(ptr)
+            };
 
             self.cap = new_cap;
             self.data = ptr;

--- a/src/world.rs
+++ b/src/world.rs
@@ -1048,6 +1048,7 @@ mod tests {
 
     #[test]
     pub fn despawn_component_entity() {
+        // TODO: Removing entities when they despawn not yet implemented
         return;
         let mut world = World::new();
 
@@ -1087,5 +1088,28 @@ mod tests {
             assert!(world.archetypes[1].entities.len() == 0);
             assert!(world.ecs_id_meta[component_entity.uindex()].is_none());
         }
+    }
+
+    // TODO: Boxy can you make the following tests actually work?
+    // Currently they basically just want to not panic, but they should check capacity if possible
+    #[test]
+    pub fn spawn() -> () {
+        let mut world = World::new();
+        let entity = world.spawn().build();
+        assert_eq!(entity, EcsId::new(0, 0));
+    }
+
+    #[test]
+    pub fn spawn_with_capacity() -> () {
+        let mut world = World::new();
+        let entity = world.spawn_with_capacity(32).build();
+        assert_eq!(entity, EcsId::new(0, 0));
+    }
+
+    #[test]
+    pub fn spawn_with_capacity_zero() -> () {
+        let mut world = World::new();
+        let entity = world.spawn_with_capacity(0).build();
+        assert_eq!(entity, EcsId::new(0, 0));
     }
 }


### PR DESCRIPTION
Changes some `.unwrap()` into `.expect(reason)` to clarify the source of the error
Adds additional error handling in some locations
Properly handles allocation errors with `handle_alloc_error`
Does not allocate in EntityBuilder when not needed